### PR TITLE
⬆️ Update minimum version of ESPhome in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         esphome/bluetoothproxy.yaml
         esphome/garagedoor.yaml
         
-      esphome-version: 2024.7.3
+      esphome-version: 2024.10.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to utilize the latest version of ESPHome (2024.10.0) for firmware builds, enhancing performance and incorporating new features.
  
- **Bug Fixes**
	- Ensured the build process reflects the latest fixes and improvements from the updated ESPHome version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->